### PR TITLE
JogAmp 2.3.1 OpenGL ES 2

### DIFF
--- a/backends/gdx-backend-jogamp/src/com/badlogic/gdx/backends/jogamp/JoglGraphicsBase.java
+++ b/backends/gdx-backend-jogamp/src/com/badlogic/gdx/backends/jogamp/JoglGraphicsBase.java
@@ -105,6 +105,10 @@ public abstract class JoglGraphicsBase implements Graphics, GLEventListener {
 			gl20 = new JoglGL20();
 		}
 
+		Gdx.gl = gl20;
+		Gdx.gl20 = gl20;
+		Gdx.gl30 = gl30;
+		
 		if (major <= 1)
 			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + major + "." + minor);
 		if (major == 2) {
@@ -117,10 +121,6 @@ public abstract class JoglGraphicsBase implements Graphics, GLEventListener {
 					+ ", FBO extension: false" + (glInfo.isEmpty() ? "" : ("\n" + glInfo)));
 			}
 		}
-
-		Gdx.gl = gl20;
-		Gdx.gl20 = gl20;
-		Gdx.gl30 = gl30;
 	}
 
 	void updateTimes () {

--- a/backends/gdx-backend-jogamp/src/com/badlogic/gdx/backends/jogamp/JoglGraphicsBase.java
+++ b/backends/gdx-backend-jogamp/src/com/badlogic/gdx/backends/jogamp/JoglGraphicsBase.java
@@ -111,7 +111,7 @@ public abstract class JoglGraphicsBase implements Graphics, GLEventListener {
 		
 		if (major <= 1)
 			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + major + "." + minor);
-		if (major == 2) {
+		if (major == 2 && !drawable.getGL().isGLES2Compatible()) {
 			if (!supportsExtension("GL_EXT_framebuffer_object") && !supportsExtension("GL_ARB_framebuffer_object")) {
 				final String vendor = drawable.getGL().glGetString(GL.GL_VENDOR);
 				final String renderer = drawable.getGL().glGetString(GL.GL_RENDERER);


### PR DESCRIPTION
Fixed two issues when taking the major == 2 codepath in JoglGraphicsBase
triggered when using OpenGL ES 2